### PR TITLE
Adding poetry and Django test structure

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)

--- a/pyproject.lock
+++ b/pyproject.lock
@@ -1,0 +1,29 @@
+[[package]]
+category = "main"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+name = "django"
+optional = false
+platform = "*"
+python-versions = ">=3.5"
+version = "2.1.2"
+
+[package.dependencies]
+pytz = "*"
+
+[[package]]
+category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+platform = "Independent"
+python-versions = "*"
+version = "2018.5"
+
+[metadata]
+content-hash = "edd900a438529cb9986246fe9a454a8af371e740ed745169c0833328eb388cae"
+platform = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[metadata.hashes]
+django = ["acdcc1f61fdb0a0c82a1d3bf1879a414e7732ea894a7632af7f6d66ec7ab5bb3", "efbcad7ebb47daafbcead109b38a5bd519a3c3cd92c6ed0f691ff97fcdd16b45"]
+pytz = ["a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053", "ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "django-expiry"
+version = "0.2.2"
+description = "Expiry rules for Django sessions."
+authors = ["Ramon Saraiva <ramonsaraiva@gmail.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+Django = ">=2.1.2"
+
+[tool.poetry.dev-dependencies]
+

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,28 @@
+import os
+
+SECRET_KEY = 'dummy'
+
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.admin',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+    'expiry',
+    'tests',
+]
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'django_expiry_test',
+    }
+}
+
+DEBUG = True

--- a/tests/test_django_expiry.py
+++ b/tests/test_django_expiry.py
@@ -1,0 +1,17 @@
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from expiry.middleware import ExpirySessionMiddleware
+
+class ExpiryMiddlewareTests(TestCase):
+
+    def setUp(self):
+        self.middleware = ExpirySessionMiddleware()
+        self.request = Mock()
+        self.response = Mock()
+
+    def test_expiry_middleware(self):
+        response = self.middleware.process_response(self.request, self.response)
+        self.assertEqual(self.request.session.get_expiry_age.call_count, 1)
+


### PR DESCRIPTION
Added some ideas for test infrastructure. Open to other suggestions! 

After installing [poetry](https://github.com/sdispater/poetry):
```
poetry install
poetry run ./manage.py test
```

The test isn't really checking anything important but I wanted to make sure all the importing logic and calling worked.