### PR TITLE
Add tox file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,11 @@ jobs:
 
     steps:
       - checkout
-      - run: sudo sudo sh -c 'curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python'
       - run:
           command: |
             mkdir -p ./test_reports
             mkdir -p ./artifacts
-      - run: poetry install
-      - run: poetry run ./manage.py test
+      - run: pip install tox && tox
 
       - store_artifacts:
           path: ./artifacts

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py35, py36
+
+[testenv]
+deps = poetry
+commands =
+    poetry install -v
+    poetry run ./manage.py test


### PR DESCRIPTION
I added the tox.ini file.
It seems that you can't test with `py27` and have the dependency of `django >= 2.1.2`.

#7 